### PR TITLE
Python 3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 cache: pip
 install:  
   - pip install -r requirements.txt

--- a/pycoincap/__init__.py
+++ b/pycoincap/__init__.py
@@ -1,1 +1,1 @@
-from core import CryptoMarket
+from pycoincap.core import CryptoMarket


### PR DESCRIPTION
Added python 3.6 in Travs CI config, now there are 2 builds - one for 2.7 and one for 3.6.
The library works with python3 (almost) out of the box - the only thing was to change the import of ```CyptoMarket``` from ```core``` to ```pycoincap.core```.